### PR TITLE
Fix the tests

### DIFF
--- a/pyiceberg/expressions/__init__.py
+++ b/pyiceberg/expressions/__init__.py
@@ -364,7 +364,7 @@ class UnboundPredicate(Generic[L], Unbound[BooleanExpression], BooleanExpression
 
     def __eq__(self, other: Any) -> bool:
         """Return the equality of two instances of the UnboundPredicate class."""
-        return self.term == other.term if isinstance(other, UnboundPredicate) else False
+        return self.term == other.term if isinstance(other, self.__class__) else False
 
     @abstractmethod
     def bind(self, schema: Schema, case_sensitive: bool = True) -> BooleanExpression:
@@ -531,7 +531,7 @@ class SetPredicate(UnboundPredicate[L], ABC):
 
     def __eq__(self, other: Any) -> bool:
         """Return the equality of two instances of the SetPredicate class."""
-        return self.term == other.term and self.literals == other.literals if isinstance(other, SetPredicate) else False
+        return self.term == other.term and self.literals == other.literals if isinstance(other, self.__class__) else False
 
     def __getnewargs__(self) -> Tuple[UnboundTerm[L], Set[Literal[L]]]:
         """Pickle the SetPredicate class."""
@@ -663,12 +663,6 @@ class NotIn(SetPredicate[L], ABC):
     def __invert__(self) -> In[L]:
         """Transform the Expression into its negated version."""
         return In[L](self.term, self.literals)
-
-    def __eq__(self, other: Any) -> bool:
-        """Return the equality of two instances of the NotIn class."""
-        if isinstance(other, NotIn):
-            return self.term == other.term and self.literals == other.literals
-        return False
 
     @property
     def as_bound(self) -> Type[BoundNotIn[L]]:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -830,15 +830,27 @@ def test_projection_truncate_string_literal_eq(bound_reference_str: BoundReferen
 
 
 def test_projection_truncate_string_literal_gt(bound_reference_str: BoundReference[str]) -> None:
-    assert TruncateTransform(2).project("name", BoundGreaterThan(term=bound_reference_str, literal=literal("data"))) == EqualTo(
-        term="name", literal=literal("da")
-    )
+    assert TruncateTransform(2).project(
+        "name", BoundGreaterThan(term=bound_reference_str, literal=literal("data"))
+    ) == GreaterThanOrEqual(term="name", literal=literal("da"))
 
 
 def test_projection_truncate_string_literal_gte(bound_reference_str: BoundReference[str]) -> None:
     assert TruncateTransform(2).project(
         "name", BoundGreaterThanOrEqual(term=bound_reference_str, literal=literal("data"))
-    ) == EqualTo(term="name", literal=literal("da"))
+    ) == GreaterThanOrEqual(term="name", literal=literal("da"))
+
+
+def test_projection_truncate_string_literal_lt(bound_reference_str: BoundReference[str]) -> None:
+    assert TruncateTransform(2).project(
+        "name", BoundLessThan(term=bound_reference_str, literal=literal("data"))
+    ) == LessThanOrEqual(term="name", literal=literal("da"))
+
+
+def test_projection_truncate_string_literal_lte(bound_reference_str: BoundReference[str]) -> None:
+    assert TruncateTransform(2).project(
+        "name", BoundLessThanOrEqual(term=bound_reference_str, literal=literal("data"))
+    ) == LessThanOrEqual(term="name", literal=literal("da"))
 
 
 def test_projection_truncate_string_set_same_result(bound_reference_str: BoundReference[str]) -> None:


### PR DESCRIPTION
Fixes the `>` and `>=` tests, and also add `<` and `<=` tests to make the set complete. 

Also some small fixes:

- Line 367 should also use `self.__class__` for `IsNull`, `IsNaN` etc.
- Can you add `self.__class__` to the SetPredicate on line 534.
- The `__eq__` of NotIn on line 667 can go (`In` doesn't have one either).
